### PR TITLE
Complete implementation for querying the Custom Search engine, parsing JSON response, and extracting URLs. Also write unit tests. Integrate news articles compilation (WebCrawler) into InfoCompiler.

### DIFF
--- a/info-compiler/README.md
+++ b/info-compiler/README.md
@@ -1,10 +1,15 @@
-This directory contains the web crawler for "Voter Central".
+This directory contains the information compiler for "Voter Central".
 
 The use of the Google Cloud Datastore client library requires the project ID to
 be configured:
 ```bash
 gcloud config set project <projectId>
 ```
+
+To use the code, please prepare and put the following in com.google.google.sps.infocompiler.Config:
+- Civic Information API key (referenced in com.google.google.sps.infocompiler.InfoCompiler)
+- Custom Search JSON API key (referenced in com.google.google.sps.webcrawler.WebCrawler)
+- Custom Engine ID (referenced in com.google.google.sps.webcrawler.WebCrawler)
 
 To run unit tests, execute this command:
 ```bash

--- a/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
+++ b/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -55,13 +54,14 @@ import org.apache.http.util.EntityUtils;
  * article information, and storing them in the database.
  */
 public class InfoCompiler {
-  private final static String CIVIC_INFO_API_KEY = Config.CIVIC_INFO_API_KEY;
   private final static String ELECTION_QUERY_URL =
-      String.format("https://www.googleapis.com/civicinfo/v2/elections?key=%s", CIVIC_INFO_API_KEY);
+      String.format("https://www.googleapis.com/civicinfo/v2/elections?key=%s",
+                    Config.CIVIC_INFO_API_KEY);
   private final static String VOTER_INFO_QUERY_URL =
-      String.format("https://www.googleapis.com/civicinfo/v2/voterinfo?key=%s", CIVIC_INFO_API_KEY);
+      String.format("https://www.googleapis.com/civicinfo/v2/voterinfo?key=%s",
+                    Config.CIVIC_INFO_API_KEY);
   private Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
-  private List<String> electionQueryIds = new LinkedList<>();
+  private List<String> electionQueryIds = new ArrayList<>();
   // For testing purposes (not to add too much information to the database).
   // Will include all 50 states.
   private List<String> states = Arrays.asList("NY");

--- a/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
+++ b/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
@@ -32,6 +32,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.sps.infocompiler.Config;
+import com.google.sps.webcrawler.NewsContentExtractor;
+import com.google.sps.webcrawler.RelevancyChecker;
+import com.google.sps.webcrawler.WebCrawler;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,6 +65,7 @@ public class InfoCompiler {
   // For testing purposes (not to add too much information to the database).
   // Will include all 50 states.
   private List<String> states = Arrays.asList("NY");
+  private WebCrawler webCrawler;
 
   public InfoCompiler() throws IOException {
     this(DatastoreOptions.getDefaultInstance().getService());
@@ -70,6 +74,8 @@ public class InfoCompiler {
   /** For testing purposes. */
   public InfoCompiler(Datastore datastore) throws IOException {
     this.datastore = datastore;
+    this.webCrawler =
+        new WebCrawler(this.datastore, new NewsContentExtractor(), new RelevancyChecker());
   }
 
   /**
@@ -124,10 +130,10 @@ public class InfoCompiler {
       return;
     }
     if (targetInfo.equals("elections")) {
+      electionQueryIds = new ArrayList<>(infoArray.size());
       for (JsonElement info : infoArray) {
         storeBaseElectionInDatabase((JsonObject) info);
       }
-      electionQueryIds = new ArrayList<>(infoArray.size());
     } else if (targetInfo.equals("contests")) {
       for (JsonElement info : infoArray) {
         storeElectionContestInDatabase(electionQueryId, (JsonObject) info);
@@ -143,20 +149,19 @@ public class InfoCompiler {
   private JsonObject queryCivicInformation(String queryUrl) throws IOException {
     CloseableHttpClient httpClient = HttpClients.createDefault();
     HttpGet httpGet = new HttpGet(queryUrl);
-    return requestHttpAndBuildJsonResponseFromCivicInformation(httpClient, httpGet);
+    return requestHttpAndBuildJsonResponse(httpClient, httpGet);
   }
 
   /** 
-   * Makes HTTP GET request to the Civic Information API amd converts HTTP JSON response as {@code
-   * JsonObject}.
+   * Makes HTTP GET request and converts HTTP JSON response as {@code JsonObject}.
    *
-   * @throws ClientProtocolException if the GET request to the Civic Information API fails.
+   * @throws ClientProtocolException if the HTTP GET request fails.
    * @see <a href=
    *    "https://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org/apache/" +
    *    "http/examples/client/ClientWithResponseHandler.java">Code reference</a>
    */
-  JsonObject requestHttpAndBuildJsonResponseFromCivicInformation(CloseableHttpClient httpClient,
-      HttpGet httpGet) throws IOException {
+  public static JsonObject requestHttpAndBuildJsonResponse(
+      CloseableHttpClient httpClient, HttpGet httpGet) throws IOException {
     ResponseHandler<String> responseHandler = new ResponseHandler<String>() {
         @Override
         public String handleResponse(final HttpResponse response) throws IOException {
@@ -252,7 +257,8 @@ public class InfoCompiler {
   // @TODO [Find incumbency.]
   /**
    * Stores information of a {@code candidate} in the database, and updates the candidate's running
-   * position's information for the election. Information includes: name, party affiliation.
+   * position's information for the election. Information includes: name, party affiliation,
+   * incumbency status, and news articles related to the candidate.
    */
   private void storeElectionContestCandidateInDatabase(JsonObject candidate,
       List<Value<String>> candidateIds, List<Value<Boolean>> candidateIncumbency) {
@@ -273,5 +279,16 @@ public class InfoCompiler {
     datastore.put(candidateEntity);
     candidateIds.add(StringValue.newBuilder(Long.toString(candidateId)).build());
     candidateIncumbency.add(BooleanValue.newBuilder(false).build());
+
+    compileAndStoreCandidateNewsArticlesInDatabase(name, new Long(candidateId).toString());
+  }
+
+  /**
+   * Compiles news articles data of {@code candidateName} and stores said data in the database.
+   * News articles data are represented by {@code NewsArticle}.
+   */
+  private void compileAndStoreCandidateNewsArticlesInDatabase(String candidateName,
+      String candidateId) {
+    webCrawler.compileNewsArticle(candidateName, candidateId);
   }
 }

--- a/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
+++ b/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
@@ -54,10 +54,9 @@ import org.apache.http.util.EntityUtils;
 
 /** A web crawler for compiling candidate-specific news articles information. */
 public class WebCrawler {
-  private static final String CUSTOM_SEARCH_KEY = Config.CUSTOM_SEARCH_KEY;
-  private static final String CUSTOM_SEARCH_ENGINE_ID = Config.CUSTOM_SEARCH_ENGINE_ID;
   private static final String CUSTOM_SEARCH_SAFE = "active";
   static final String CUSTOM_SEARCH_URL_METATAG = "og:url";
+
   // @TODO [Extract publisher and published date.]
   // private static final String CUSTOM_SEARCH_PUBLISHED_DATE_METATAGS =
   //     Arrays.asList("article:published_time", "article:modified_time", "modified", og:pubdate",
@@ -153,7 +152,8 @@ public class WebCrawler {
     String request =
         String.format(
             "https://www.googleapis.com/customsearch/v1?key=%s&cx=%s&q=%s",
-            CUSTOM_SEARCH_KEY, CUSTOM_SEARCH_ENGINE_ID, candidateName.replace(" ", "%20"));
+            Config.CUSTOM_SEARCH_KEY, Config.CUSTOM_SEARCH_ENGINE_ID,
+            candidateName.replace(" ", "%20"));
     CloseableHttpClient httpClient = HttpClients.createDefault();
     try {
       HttpGet httpGet = new HttpGet(request);

--- a/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
+++ b/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
@@ -58,14 +58,7 @@ public class WebCrawler {
   static final String CUSTOM_SEARCH_URL_METATAG = "og:url";
 
   // @TODO [Extract publisher and published date.]
-  // private static final String CUSTOM_SEARCH_PUBLISHED_DATE_METATAGS =
-  //     Arrays.asList("article:published_time", "article:modified_time", "modified", og:pubdate",
-  //                   "pubdate", "published", "dcterms.modified", "dcterms.created");
-  // private static final String CUSTOM_SEARCH_PUBLISHER_METATAGS =
-  //     Arrays.asList("article:publisher", "og:site_name", "twitter:app:name:googleplay",
-  //                   "dc.source");
   // @TODO [Decide between extracting title from Custom Search or NewsContentExtractor.]
-  // private static final String CUSTOM_SEARCH_TITLE_METATAG = "og:title";
   private static final int CUSTOM_SEARCH_RESULT_COUNT = 10;
   private Datastore datastore;
   private NewsContentExtractor newsContentExtractor;

--- a/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
+++ b/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
@@ -20,8 +20,13 @@ import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.StringValue;
-import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.sps.data.NewsArticle;
+import com.google.sps.infocompiler.Config;
+import com.google.sps.infocompiler.InfoCompiler;
 import com.google.sps.webcrawler.NewsContentExtractor;
 import com.google.sps.webcrawler.NewsContentProcessor;
 import com.google.sps.webcrawler.RelevancyChecker;
@@ -30,6 +35,7 @@ import com.panforge.robotstxt.RobotsTxt;
 import java.io.InputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -48,10 +54,20 @@ import org.apache.http.util.EntityUtils;
 
 /** A web crawler for compiling candidate-specific news articles information. */
 public class WebCrawler {
-  private static final String CUSTOM_SEARCH_KEY = "";
-  private static final String CUSTOM_SEARCH_ENGINE_ID = "";
-  private static final String TEST_URL =
-      "https://www.cnn.com/2020/06/23/politics/aoc-ny-primary-14th-district/index.html";
+  private static final String CUSTOM_SEARCH_KEY = Config.CUSTOM_SEARCH_KEY;
+  private static final String CUSTOM_SEARCH_ENGINE_ID = Config.CUSTOM_SEARCH_ENGINE_ID;
+  private static final String CUSTOM_SEARCH_SAFE = "active";
+  static final String CUSTOM_SEARCH_URL_METATAG = "og:url";
+  // @TODO [Extract publisher and published date.]
+  // private static final String CUSTOM_SEARCH_PUBLISHED_DATE_METATAGS =
+  //     Arrays.asList("article:published_time", "article:modified_time", "modified", og:pubdate",
+  //                   "pubdate", "published", "dcterms.modified", "dcterms.created");
+  // private static final String CUSTOM_SEARCH_PUBLISHER_METATAGS =
+  //     Arrays.asList("article:publisher", "og:site_name", "twitter:app:name:googleplay",
+  //                   "dc.source");
+  // @TODO [Decide between extracting title from Custom Search or NewsContentExtractor.]
+  // private static final String CUSTOM_SEARCH_TITLE_METATAG = "og:title";
+  private static final int CUSTOM_SEARCH_RESULT_COUNT = 10;
   private Datastore datastore;
   private NewsContentExtractor newsContentExtractor;
   private RelevancyChecker relevancyChecker;
@@ -71,7 +87,7 @@ public class WebCrawler {
   }
 
   /** For testing purposes. */
-  WebCrawler(Datastore datastore, NewsContentExtractor newsContentExtractor,
+  public WebCrawler(Datastore datastore, NewsContentExtractor newsContentExtractor,
       RelevancyChecker relevancyChecker) throws IOException {
     this.datastore = datastore;
     this.newsContentExtractor = newsContentExtractor;
@@ -122,10 +138,10 @@ public class WebCrawler {
   //   } catch (InterruptedException e) {}
   // }
 
-  // @TODO [Test with Google Custom Search. Extract other metadata.]
+  // @TODO [Extract other metadata, modify NewsArticle's structure, and return List<NewsArticle>.]
   /**
-   * Searches for {@code candidateName} in the Google Custom Search engine and finds URLs of news
-   * articles. Returns an empty list if no valid URLs are found.
+   * Searches for {@code candidateName} on News.google using the Google Custom Search engine and
+   * finds URLs of news articles. Returns an empty list if no valid URLs are found.
    * Note: This function contains a few hard-coded implementations because of the current lack of
    * access to the engine. In order for the web crawler to be tested from beginning to end, this
    * function creates hard-coded URLs for {@code scrapeAndExtractHtml()} to scrape.
@@ -134,36 +150,41 @@ public class WebCrawler {
    *    + "http/examples/client/ClientWithResponseHandler.java">Code reference</a>
    */
   public List<URL> getUrlsFromCustomSearch(String candidateName) {
-    List<URL> urls = Arrays.asList();
     String request =
         String.format(
             "https://www.googleapis.com/customsearch/v1?key=%s&cx=%s&q=%s",
             CUSTOM_SEARCH_KEY, CUSTOM_SEARCH_ENGINE_ID, candidateName.replace(" ", "%20"));
-    CloseableHttpClient httpclient = HttpClients.createDefault();
+    CloseableHttpClient httpClient = HttpClients.createDefault();
     try {
-      urls = Arrays.asList(new URL(TEST_URL));
       HttpGet httpGet = new HttpGet(request);
-      ResponseHandler<String> responseHandler =
-          new ResponseHandler<String>() {
-              @Override
-              public String handleResponse(final HttpResponse response) throws IOException {
-                int status = response.getStatusLine().getStatusCode();
-                if (status >= 200 && status < 300) {
-                    HttpEntity entity = response.getEntity();
-                    return entity != null ? EntityUtils.toString(entity) : null;
-                } else {
-                    httpclient.close();
-                    throw new ClientProtocolException("Unexpected response status: " + status);
-                }
-              }
-      };
-      String responseBody = httpclient.execute(httpGet, responseHandler);
-      httpclient.close();
-      Gson gson = new Gson();
-      Object jsonResponse = gson.fromJson(responseBody, Object.class);
-      // @TODO [Unpack {@code jsonResponse} and find URLs.]
+      JsonObject json = InfoCompiler.requestHttpAndBuildJsonResponse(httpClient, httpGet);
+      return extractUrlsFromCustomSearchJson(json);
     } catch (IOException e) {
       System.out.println("[ERROR] Error occurred with fetching URLs from Custom Search: " + e);
+      return Arrays.asList();
+    }
+  }
+
+  // @TODO [Extract other metadata and store into the updated NewsArticle structure.]
+  /**
+   * Parses {@code json}, which is in Google Custom Search's JSON response format, and extracts
+   * news articles' URLs (URLs from the source website, instead of from News.google).
+   */
+  List<URL> extractUrlsFromCustomSearchJson(JsonObject json) {
+    List<URL> urls = new ArrayList<>(CUSTOM_SEARCH_RESULT_COUNT);
+    JsonArray searchResults = json.getAsJsonArray("items");
+    for (JsonElement result : searchResults) {
+      JsonObject metadata =
+          (JsonObject)
+              (((JsonObject) result)
+                   .getAsJsonObject("pagemap")
+                       .getAsJsonArray("metatags")
+                           .get(0));
+      try {
+        urls.add(
+            new URL(
+                metadata.get(CUSTOM_SEARCH_URL_METATAG).getAsString()));
+      } catch (Exception e) {}
     }
     return urls;
   }

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -43,7 +43,6 @@ import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -140,7 +139,7 @@ public final class InfoCompilerTest {
         ArgumentCaptor.forClass(ResponseHandler.class);
     when(httpClient.execute(anyObject(), argumentCaptor.capture())).thenReturn(ELECTION_RESPONSE);
     JsonObject json =
-        infoCompiler.requestHttpAndBuildJsonResponseFromCivicInformation(httpClient, httpGet);
+        InfoCompiler.requestHttpAndBuildJsonResponse(httpClient, httpGet);
     assertThat(json).isEqualTo(ELECTION_JSON);
   }
 

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -77,8 +77,8 @@ public final class InfoCompilerTest {
       " ]" +
       "}";
   private static final boolean PLACEHOLDER_INCUMBENCY = false;
-  private static JsonObject ELECTION_JSON;
-  private static JsonObject SINGLE_CONTEST_JSON;
+  private static JsonObject electionJson;
+  private static JsonObject singleContestJson;
   private static InfoCompiler infoCompiler;
   private static LocalDatastoreHelper datastoreHelper;
   private static Datastore datastore;
@@ -96,18 +96,18 @@ public final class InfoCompilerTest {
     election.addProperty("electionDay", "2013-06-06");
     JsonArray elections = new JsonArray();
     elections.add(election);
-    ELECTION_JSON = new JsonObject();
-    ELECTION_JSON.addProperty("kind", "civicinfo#electionsqueryresponse");
-    ELECTION_JSON.add("elections", elections);
+    electionJson = new JsonObject();
+    electionJson.addProperty("kind", "civicinfo#electionsqueryresponse");
+    electionJson.add("elections", elections);
 
     JsonObject candidate = new JsonObject();
     candidate.addProperty("name", "Andrew Cuomo");
     candidate.addProperty("party", "Democratic");
     JsonArray candidates = new JsonArray();
     candidates.add(candidate);
-    SINGLE_CONTEST_JSON = new JsonObject();
-    SINGLE_CONTEST_JSON.addProperty("office", "Governor");
-    SINGLE_CONTEST_JSON.add("candidates", candidates);
+    singleContestJson = new JsonObject();
+    singleContestJson.addProperty("office", "Governor");
+    singleContestJson.add("candidates", candidates);
   }
 
   /**
@@ -130,9 +130,9 @@ public final class InfoCompilerTest {
     // {@code ResponseHandler<String>} that converts any {@code HttpResponse} response to {@code
     // ELECTION_RESPONSE}, and subsequently convert {@code ELECTION_RESPONSE} to {@code json}.
     // {@code httpGet} is irrelevant in this test, since {@code execute()} is mocked as above.
-    // Since String {@code ELECTION_RESPONSE} and JsonObject {@code ELECTION_JSON} match in
-    // content, {@code json} should be exactly the same as {@code ELECTION_JSON}. Here, we don't
-    // repeatedly test the same thing with {@code SINGLE_CONTEST_JSON}.
+    // Since String {@code ELECTION_RESPONSE} and JsonObject {@code electionJson} match in
+    // content, {@code json} should be exactly the same as {@code electionJson}. Here, we don't
+    // repeatedly test the same thing with {@code singleContestJson}.
     CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
     HttpGet httpGet = new HttpGet(ELECTION_QUERY_URL);
     ArgumentCaptor<ResponseHandler<String>> argumentCaptor =
@@ -140,17 +140,17 @@ public final class InfoCompilerTest {
     when(httpClient.execute(anyObject(), argumentCaptor.capture())).thenReturn(ELECTION_RESPONSE);
     JsonObject json =
         InfoCompiler.requestHttpAndBuildJsonResponse(httpClient, httpGet);
-    assertThat(json).isEqualTo(ELECTION_JSON);
+    assertThat(json).isEqualTo(electionJson);
   }
 
   @Test
   public void storeBaseElectionInDatabase_checkDatastoreEntityConstructionFromJson()
       throws IOException {
-    // Parse and re-structure base election information from {@code ELECTION_JSON}'s
+    // Parse and re-structure base election information from {@code electionJson}'s
     // "elections" section and store the corresponding entity in the database. Said
-    // entity should contain information that is consistent with that in {@code ELECTION_JSON}.
+    // entity should contain information that is consistent with that in {@code electionJson}.
     // A Datastore emulator is used to simulate Datastore operations, as opposed to Mockito mocks.
-    JsonObject election = (JsonObject) ELECTION_JSON.getAsJsonArray("elections").get(0);
+    JsonObject election = (JsonObject) electionJson.getAsJsonArray("elections").get(0);
     String[] yearMonthDay = election.get("electionDay").getAsString().split("-");
     Date date = new Date(
         Integer.parseInt(yearMonthDay[0]) - 1900,
@@ -180,21 +180,21 @@ public final class InfoCompilerTest {
   public void storeElectionContestInDatabase_checkDatastoreEntityConstructionFromJson()
       throws IOException {
     // Parse and re-structure election/position/candidate information from {@code
-    // SINGLE_CONTEST_JSON}. Create a correponding candidate entity and update the existing
+    // singleContestJson}. Create a correponding candidate entity and update the existing
     // election entity in the database. Said entities should contain information that is consistent
-    // with that in {@code SINGLE_CONTEST_JSON}. A Datastore emulator is used to simulate Datastore
+    // with that in {@code singleContestJson}. A Datastore emulator is used to simulate Datastore
     // operations, as opposed to Mockito mocks.
     // This method relies on the election entity created by {@code storeBaseElectionInDatabase()}
     // and thus assumes the correctness of said method. This method avoids repeating any tests
     // executed by {@code storeBaseElectionInDatabase_checkDatastoreEntityConstructionFromJson()}.
-    JsonObject election = (JsonObject) ELECTION_JSON.getAsJsonArray("elections").get(0);
-    JsonObject candidate = (JsonObject) SINGLE_CONTEST_JSON.getAsJsonArray("candidates").get(0);
+    JsonObject election = (JsonObject) electionJson.getAsJsonArray("elections").get(0);
+    JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
                                 + candidate.get("party").getAsString().hashCode());
 
     infoCompiler.storeBaseElectionInDatabase(election);
     infoCompiler.storeElectionContestInDatabase(election.get("id").getAsString(),
-                                                SINGLE_CONTEST_JSON);
+                                                singleContestJson);
     // Check data additions to the election entity.
     Query<Entity> electionQuery =
         Query.newEntityQueryBuilder()
@@ -206,7 +206,7 @@ public final class InfoCompilerTest {
     assertThat(candidatePositions).hasSize(1);
     assertThat(candidatePositions)
         .containsExactly(StringValue.newBuilder(
-                         SINGLE_CONTEST_JSON.get("office").getAsString()).build());
+                         singleContestJson.get("office").getAsString()).build());
     List<Value<String>> candidateIds =
         new ArrayList<>(electionEntity.getList("candidateIds"));
     assertThat(candidateIds).hasSize(1);

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -90,23 +90,23 @@ public final class InfoCompilerTest {
     datastore = datastoreHelper.getOptions().getService();
     infoCompiler = new InfoCompiler(datastore);
 
-    ELECTION_JSON = new JsonObject();
-    ELECTION_JSON.addProperty("kind", "civicinfo#electionsqueryresponse");
-    JsonArray elections = new JsonArray(1);
     JsonObject election = new JsonObject();
     election.addProperty("id", "2000");
     election.addProperty("name", "VIP Test Election");
     election.addProperty("electionDay", "2013-06-06");
+    JsonArray elections = new JsonArray();
     elections.add(election);
+    ELECTION_JSON = new JsonObject();
+    ELECTION_JSON.addProperty("kind", "civicinfo#electionsqueryresponse");
     ELECTION_JSON.add("elections", elections);
 
-    SINGLE_CONTEST_JSON = new JsonObject();
-    SINGLE_CONTEST_JSON.addProperty("office", "Governor");
-    JsonArray candidates = new JsonArray(1);
     JsonObject candidate = new JsonObject();
     candidate.addProperty("name", "Andrew Cuomo");
     candidate.addProperty("party", "Democratic");
+    JsonArray candidates = new JsonArray();
     candidates.add(candidate);
+    SINGLE_CONTEST_JSON = new JsonObject();
+    SINGLE_CONTEST_JSON.addProperty("office", "Governor");
     SINGLE_CONTEST_JSON.add("candidates", candidates);
   }
 

--- a/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
@@ -106,17 +106,17 @@ public final class WebCrawlerTest {
     //   ]
     //   ...
     // }
-    CUSTOM_SEARCH_JSON = new JsonObject();
-    JsonArray items = new JsonArray(1);
-    JsonObject item = new JsonObject();
-    JsonObject pagemap = new JsonObject();
-    JsonArray metatags = new JsonArray(1);
     JsonObject urlMetadata = new JsonObject();
     urlMetadata.addProperty(WebCrawler.CUSTOM_SEARCH_URL_METATAG, VALID_URL);
+    JsonArray metatags = new JsonArray();
     metatags.add(urlMetadata);
+    JsonObject pagemap = new JsonObject();
     pagemap.add("metatags", metatags);
+    JsonObject item = new JsonObject();
     item.add("pagemap", pagemap);
+    JsonArray items = new JsonArray();
     items.add(item);
+    CUSTOM_SEARCH_JSON = new JsonObject();
     CUSTOM_SEARCH_JSON.add("items", items);
   }
 

--- a/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
@@ -72,7 +72,7 @@ public final class WebCrawlerTest {
   private static Datastore datastore;
   private static NewsContentExtractor newsContentExtractor;
   private static RelevancyChecker relevancyChecker;
-  private static JsonObject CUSTOM_SEARCH_JSON;
+  private static JsonObject customSearchJson;
 
   @BeforeClass
   public static void initialize() throws InterruptedException, IOException {
@@ -83,7 +83,7 @@ public final class WebCrawlerTest {
     relevancyChecker = mock(RelevancyChecker.class);
     webCrawler = new WebCrawler(datastore, newsContentExtractor, relevancyChecker);
 
-    // {@code CUSTOM_SEARCH_JSON} has the following JSON structure (ellipsis represents other
+    // {@code customSearchJson} has the following JSON structure (ellipsis represents other
     // properties not shown). Insert {@code VALID_URL}.
     // {
     //   ...
@@ -116,8 +116,8 @@ public final class WebCrawlerTest {
     item.add("pagemap", pagemap);
     JsonArray items = new JsonArray();
     items.add(item);
-    CUSTOM_SEARCH_JSON = new JsonObject();
-    CUSTOM_SEARCH_JSON.add("items", items);
+    customSearchJson = new JsonObject();
+    customSearchJson.add("items", items);
   }
 
   /**
@@ -136,9 +136,9 @@ public final class WebCrawlerTest {
 
   @Test
   public void extractUrlsFromCustomSearchJson() throws IOException {
-    // Extract news article URL from {@code CUSTOM_SEARCH_JSON}, which is in format @see
+    // Extract news article URL from {@code customSearchJson}, which is in format @see
     // {@code initialize()}.
-    List<URL> urls = webCrawler.extractUrlsFromCustomSearchJson(CUSTOM_SEARCH_JSON);
+    List<URL> urls = webCrawler.extractUrlsFromCustomSearchJson(customSearchJson);
     assertThat(urls).containsExactly(new URL(VALID_URL));
   }
 

--- a/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
@@ -24,11 +24,14 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.google.sps.data.NewsArticle;
 import com.panforge.robotstxt.Grant;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.TimeoutException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.AfterClass;
@@ -69,6 +72,7 @@ public final class WebCrawlerTest {
   private static Datastore datastore;
   private static NewsContentExtractor newsContentExtractor;
   private static RelevancyChecker relevancyChecker;
+  private static JsonObject CUSTOM_SEARCH_JSON;
 
   @BeforeClass
   public static void initialize() throws InterruptedException, IOException {
@@ -78,6 +82,42 @@ public final class WebCrawlerTest {
     newsContentExtractor = mock(NewsContentExtractor.class);
     relevancyChecker = mock(RelevancyChecker.class);
     webCrawler = new WebCrawler(datastore, newsContentExtractor, relevancyChecker);
+
+    // {@code CUSTOM_SEARCH_JSON} has the following JSON structure (ellipsis represents other
+    // properties not shown). Insert {@code VALID_URL}.
+    // {
+    //   ...
+    //   "items": [
+    //     {
+    //       ...
+    //       "pagemap": {
+    //         ...
+    //         "metatags": [
+    //           {
+    //             ...
+    //             {@code WebCrawler.CUSTOM_SEARCH_URL_METATAG}: <URL>,
+    //             ...
+    //           }
+    //         ]
+    //         ...
+    //       }
+    //       ...
+    //     }
+    //   ]
+    //   ...
+    // }
+    CUSTOM_SEARCH_JSON = new JsonObject();
+    JsonArray items = new JsonArray(1);
+    JsonObject item = new JsonObject();
+    JsonObject pagemap = new JsonObject();
+    JsonArray metatags = new JsonArray(1);
+    JsonObject urlMetadata = new JsonObject();
+    urlMetadata.addProperty(WebCrawler.CUSTOM_SEARCH_URL_METATAG, VALID_URL);
+    metatags.add(urlMetadata);
+    pagemap.add("metatags", metatags);
+    item.add("pagemap", pagemap);
+    items.add(item);
+    CUSTOM_SEARCH_JSON.add("items", items);
   }
 
   /**
@@ -94,9 +134,13 @@ public final class WebCrawlerTest {
     webCrawler = new WebCrawler(datastore, newsContentExtractor, relevancyChecker);
   }
 
-  // @TODO [Implement unit tests for getting URLs from the Custom Search engine.]
   @Test
-  public void getUrlsFromCustomSearch() {}
+  public void extractUrlsFromCustomSearchJson() throws IOException {
+    // Extract news article URL from {@code CUSTOM_SEARCH_JSON}, which is in format @see
+    // {@code initialize()}.
+    List<URL> urls = webCrawler.extractUrlsFromCustomSearchJson(CUSTOM_SEARCH_JSON);
+    assertThat(urls).containsExactly(new URL(VALID_URL));
+  }
 
   // @TODO [Write tests that test invalid URL protocols and invalid hosts, either by mocking
   // {@code URL}, which is a final class that requires additional Mockito configuration, or by


### PR DESCRIPTION
### Complete implementation for querying the Custom Search engine, parsing JSON response, and extracting news articles URLs. Also write unit tests for Custom Search JSON parsing. Integrate news articles compilation (WebCrawler) into InfoCompiler.

### What is a quick description of the change?

**1. Configure and set up a Custom Search engine, for searching Google News.**


**2. In `WebCrawler`, make HTTP GET request to the Custom Search engine, parse JSON response, and extract news articles URLs.**
- The Custom Search engine returns 10 search results per page. WebCrawler currently parses the first page and extracts a maximum of 10 URLs.
- WebCrawler shares the same Datastore service instance as InfoCompiler.
- The specific JSON response structure of Custom Search can be viewed [here](https://github.com/googleinterns/voter-central/blob/kathy_custom_search_and_news_articles_integration/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java#L86).

**3. Write unit tests for `WebCrawler`’s Custom Search functionality.**

**4. Integrate `WebCrawler` (news articles compilation) into `InfoCompiler` (all-information compilation), which feeds `candidateName` and `candidateId` into `WebCrawler` and initiates the news articles search, for each candidate.**

**5. Update [README](https://github.com/googleinterns/voter-central/blob/kathy_custom_search_and_news_articles_integration/info-compiler/README.md) to specify the necessary parameters (such as API keys) to fill in.**

**6. Future TODOs:**
- Change `NewsArticle`'s structure to contain publisher, published date and change `NewsArticle`'s interface.
- Extract publisher, published date, maybe new article title (currently `NewsContentExtractor` is in charge of finding the title), at the Custom Search step, and package these metadata to the updated `NewsArticle`, instead of only a `URL`.

[Currently holding this off, because these actions change the `NewsArticle` interface, as well as many methods' interface in `WebCrawler`, which mostly handles a list of `URL`s instead of a list of `NewsArticle`s containing URLs and other metadata. There are pull requests open that rely on the old interfaces.]

### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [ x ] Test written/updating
- [ x ] Tests passing
- [ x ] Coding style (indentation, etc)

Please explain why any are not present, if any.
