### PR TITLE
Add feature to list all elections on the directory page.

### DIFF
--- a/project/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -94,9 +94,9 @@ public class DataServlet extends HttpServlet {
       }
       List<Position> positions =
           extractPositionInformation(candidatePositionsData, candidateIdsData,
-                                    candidateIncumbencyData);
+                                     candidateIncumbencyData);
       elections.add(new Election(election.getKey().getName(),
-                                (Date) election.getProperty("date"), positions));
+                                 (Date) election.getProperty("date"), positions));
     }
     return elections;
   }
@@ -109,7 +109,6 @@ public class DataServlet extends HttpServlet {
    */
   private List<Position> extractPositionInformation(List<String> candidatePositions,
       List<String> candidateIds, List<Boolean> candidateIncumbency) {
-    System.out.println(candidatePositions);
     Set<String> distinctPositions = new HashSet<>(candidatePositions);
     List<Position> positions = new ArrayList<>(distinctPositions.size());
     for (String positionName : distinctPositions) {

--- a/project/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -85,10 +85,19 @@ public class DataServlet extends HttpServlet {
       if (!isRelevantElection(election, address, listAll)) {
         continue;
       }
+      List<String> candidatePositionsData = 
+          (List<String>) election.getProperty("candidatePositions");
+      List<String> candidateIdsData = 
+          (List<String>) election.getProperty("candidateIds");
+      List<Boolean> candidateIncumbencyData = 
+          (List<Boolean>) election.getProperty("candidateIncumbency");
+      if (candidatePositionsData == null || candidateIdsData == null 
+          || candidateIncumbencyData == null) {
+        continue;
+      }
       List<Position> positions =
-          extractPositionInformation((List<String>) election.getProperty("candidatePositions"),
-          (List<String>) election.getProperty("candidateIds"),
-          (List<Boolean>) election.getProperty("candidateIncumbency"));
+          extractPositionInformation(
+                  candidatePositionsData, candidateIdsData, candidateIncumbencyData);
       elections.add(new Election(election.getKey().getName(),
           (Date) election.getProperty("date"), positions));
     }
@@ -97,12 +106,13 @@ public class DataServlet extends HttpServlet {
 
   /**
    * Formats a list of positions and their associated candidates' information. Correlates
-   * a {@code Position} object with one or more {@code DierctoryCandidate}. Candidates running
+   * a {@code Position} object with one or more {@code DirectoryCandidate}. Candidates running
    * for the same position are assumed to be consecutive in {@code candidateIds} and
    * {@code candidateIncumbency}.
    */
   private List<Position> extractPositionInformation(List<String> candidatePositions,
       List<String> candidateIds, List<Boolean> candidateIncumbency) {
+    System.out.println(candidatePositions);
     Set<String> distinctPositions = new HashSet<>(candidatePositions);
     List<Position> positions = new ArrayList<>(distinctPositions.size());
     for (String positionName : distinctPositions) {
@@ -147,7 +157,7 @@ public class DataServlet extends HttpServlet {
     } else {
       // TODO: Add code which uses the Civic Information API to determine whether a given
       // election is relevant.
-      return true;
+      return false;
     }
   }
 

--- a/project/src/main/webapp/index.html
+++ b/project/src/main/webapp/index.html
@@ -25,7 +25,13 @@
         <br>
         <input type="text" id="address" name="address" placeholder="...your street address..."
                 required/>
+        <input type="hidden" name="listAll" value="false"/>
         <input type="submit" id="submit-address"/>
+      </form>
+      <form id="list-all-input" action="/directory.html">
+        <input type="hidden" name="address" value="default"/>
+        <input type="hidden" name="listAll" value="true"/>
+        <input type="submit" id="submit-list-all" value="List All Elections"/>
       </form>
     </main>
   </body>

--- a/project/src/main/webapp/index.html
+++ b/project/src/main/webapp/index.html
@@ -25,12 +25,12 @@
         <br>
         <input type="text" id="address" name="address" placeholder="...your street address..."
                 required/>
-        <input type="hidden" name="listAll" value="false"/>
+        <input type="hidden" name="listAllElections" value="false"/>
         <input type="submit" id="submit-address"/>
       </form>
       <form id="list-all-input" action="/directory.html">
         <input type="hidden" name="address" value="default"/>
-        <input type="hidden" name="listAll" value="true"/>
+        <input type="hidden" name="listAllElections" value="true"/>
         <input type="submit" id="submit-list-all" value="List All Elections"/>
       </form>
     </main>

--- a/project/src/main/webapp/script.js
+++ b/project/src/main/webapp/script.js
@@ -48,11 +48,11 @@
 async function addBriefElectionCandidateInformation() {
   const address = location.search.substring(location.search.indexOf('=') + 1,
       location.search.indexOf('&'));
-  const listAll =
+  const listAllElections =
       location.search.substring(location.search.lastIndexOf('=') + 1);
 
   // Send GET request to /data with address and whether to list all elections.
-  const response = await fetch(`/data?address=${address}&listAll=${listAll}`);
+  const response = await fetch(`/data?address=${address}&listAllElections=${listAllElections}`);
   const dataPackage = await response.json();
   const elections = dataPackage.electionsData;
 

--- a/project/src/main/webapp/script.js
+++ b/project/src/main/webapp/script.js
@@ -46,10 +46,13 @@
  *   </div>
  */
 async function addBriefElectionCandidateInformation() {
-  const address = location.search.substring(location.search.indexOf('=') + 1);
+  const address = location.search.substring(location.search.indexOf('=') + 1,
+      location.search.indexOf('&'));
+  const listAll =
+      location.search.substring(location.search.lastIndexOf('=') + 1);
 
-  // Send GET request to /data with address.
-  const response = await fetch(`/data?address=${address}`);
+  // Send GET request to /data with address and whether to list all elections.
+  const response = await fetch(`/data?address=${address}&listAll=${listAll}`);
   const dataPackage = await response.json();
   const elections = dataPackage.electionsData;
 


### PR DESCRIPTION
### What is a quick description of the change?

This PR adds a "List All Elections" button to the landing page, which allows the user to view all elections stored in the database on the directory page. It also refactors the data servlet. Going forward, election information will generally be retrieved as follows:

- Retrieve a list of all elections from the database
- Check if the `listAll` parameter is true; if it is, return the list of all elections.
- If the parameter is false, use the Civic Information API to determine whether each election is relevant to the provided address. Return a list of only the relevant elections.

### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [  ] Test written/updating
- [X] Tests passing
- [X] Coding style (indentation, etc)

Please explain why any are not present, if any.

### Any additional comments?
