### PR TITLE
Implement location-based search: user input address resolution when serving information, and write unit tests.

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -5,6 +5,7 @@ To run a local server, execute this command:
 ```bash
 mvn package appengine:run
 ```
+
 The project requires the use of AngularJS. To install, make sure you have
 a recent version of `npm` installed. Then run this command under
 `src/main/webapp/`:
@@ -12,3 +13,7 @@ a recent version of `npm` installed. Then run this command under
 ```bash
 npm install angular
 ```
+
+The project backend requires the use of the
+[Civic Information API](https://developers.google.com/civic-information).
+Set the API key in project/src/main/java/com/google/sps/servlets/Config.java.

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.12</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -29,6 +29,24 @@
       <version>1.9.59</version>
     </dependency>
     <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -34,9 +34,26 @@
       <version>2.8.6</version>
     </dependency>
     <dependency>
+      <groupId>com.google.truth.extensions</groupId>
+      <artifactId>truth-java8-extension</artifactId>
+      <version>0.32</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.12</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
     </dependency>
   </dependencies>
 

--- a/project/src/main/java/com/google/sps/data/NewsArticle.java
+++ b/project/src/main/java/com/google/sps/data/NewsArticle.java
@@ -25,7 +25,9 @@ public class NewsArticle {
   private String publisher;
   private Date publishedDate;
   private String content;
+  // The first 100 words of {@code content}.
   private String abbreviatedContent;
+  // The 5 most important sentences extracted from {@code content}.
   private String summarizedContent;
   private int priority;
   private NewsArticleCategory category;

--- a/project/src/main/java/com/google/sps/data/NewsArticle.java
+++ b/project/src/main/java/com/google/sps/data/NewsArticle.java
@@ -25,15 +25,21 @@ public class NewsArticle {
   private String publisher;
   private Date publishedDate;
   private String content;
+  private String abbreviatedContent;
+  private String summarizedContent;
+  private int priority;
   private NewsArticleCategory category;
 
   public NewsArticle(String title, String url, String publisher, Date publishedDate,
-      String content) {
+      String content, String abbreviatedContent, String summarizedContent, int priority) {
     this.title = title;
     this.url = url;
     this.publisher = publisher;
     this.publishedDate = publishedDate;
     this.content = content;
+    this.abbreviatedContent = abbreviatedContent;
+    this.summarizedContent = summarizedContent;
+    this.priority = priority;
     this.category = null;
   }
 }

--- a/project/src/main/java/com/google/sps/servlets/CandidateServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/CandidateServlet.java
@@ -127,7 +127,10 @@ public class CandidateServlet extends HttpServlet {
               (String) newsArticle.getProperty("url"),
               (String) newsArticle.getProperty("publisher"),
               (Date) newsArticle.getProperty("publishedDate"),
-              (String) newsArticle.getProperty("content"));
+              (String) newsArticle.getProperty("content"),
+              (String) newsArticle.getProperty("abbreviatedContent"),
+              (String) newsArticle.getProperty("summarizedContent"),
+              ((Long) newsArticle.getProperty("priority")).intValue());
       newsArticlesData.add(newsArticleData);
     }
     return newsArticlesData;

--- a/project/src/main/java/com/google/sps/servlets/Config.java
+++ b/project/src/main/java/com/google/sps/servlets/Config.java
@@ -1,0 +1,22 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+/**
+ * A configuration class for keeping hidden API keys.
+ */
+public class Config {
+  public static final String CIVIC_INFO_API_KEY = "";
+}

--- a/project/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -33,6 +33,8 @@ import com.google.sps.data.DirectoryCandidate;
 import com.google.sps.data.Election;
 import com.google.sps.data.Position;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.lang.Boolean;
 import java.net.SocketException;
 import java.util.ArrayList;
@@ -145,7 +147,7 @@ public class DataServlet extends HttpServlet {
       // {@code address}.
       String queryUrl =
         String.format("%s&address=%s&electionId=%s&officialOnly=true", VOTER_INFO_QUERY_URL,
-                      address.replace(" ", "%20").replace("\"", "%22").replace(",", "%2C"),
+                      URLEncoder.encode(address),
                       (String) election.getProperty("queryId"));
       String addressElectionResponse;
       try {

--- a/project/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -194,7 +194,10 @@ public class DataServlet extends HttpServlet {
    */
   boolean parseResponseForRelevancy(String addressElectionResponse) {
     JsonObject responseJson = new JsonParser().parse(addressElectionResponse).getAsJsonObject();
-    return responseJson.has("contests");
+    JsonArray sources =
+        ((JsonObject) responseJson.getAsJsonArray("state").get(0))
+            .getAsJsonArray("sources");
+    return !(((JsonObject)sources.get(0)).get("name").getAsString().equals(""));
   }
 
   /**

--- a/project/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -138,7 +138,7 @@ public class DataServlet extends HttpServlet {
    * this election is deemed relevant to the given {@code address}. If the {@code listAll}
    * parameter is true, then the election is always deemed relevant.
    */
-  private boolean isRelevantElection(Entity election, String address, boolean listAllElections) {
+  boolean isRelevantElection(Entity election, String address, boolean listAllElections) {
     resetRelevantNonspecificFlag();
     if (listAllElections) {
       return true;
@@ -168,7 +168,7 @@ public class DataServlet extends HttpServlet {
    *     as the election query ID, causing {@code httpclient.execute(httpGet, responseHandler);}
    *     to fail.
    */
-  private String queryCivicInformation(String queryUrl) throws IOException, SocketException {
+  String queryCivicInformation(String queryUrl) throws IOException, SocketException {
     CloseableHttpClient httpClient = HttpClients.createDefault();
     HttpGet httpGet = new HttpGet(queryUrl);
     String responseBody = requestHttpAndBuildCivicInfoResponse(httpClient, httpGet);

--- a/project/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -67,7 +67,7 @@ public class DataServlet extends HttpServlet {
   private final static String RELEVANT_NONSPECIFIC_ADDRESS_ALERT =
       "Your input address was not specific enough or was not a residential address.\n" + 
       "We are providing all possible elections that may be relevant.";
-  boolean isAddressRelevantButNonspecificOrNonresidential;
+  boolean isAddressRelevantButNotSpecificOrResidential;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -78,7 +78,7 @@ public class DataServlet extends HttpServlet {
     List<Election> elections = extractElectionInformation(address, listAllElections);
     DirectoryPageDataPackage dataPackage =
         new DirectoryPageDataPackage(elections,
-                                     isAddressRelevantButNonspecificOrNonresidential
+                                     isAddressRelevantButNotSpecificOrResidential
                                      ? RELEVANT_NONSPECIFIC_ADDRESS_ALERT
                                      : null);
     Gson gson = new Gson();
@@ -93,7 +93,7 @@ public class DataServlet extends HttpServlet {
    * Resets the flag for whether the user input address is relevant but nonspecific.
    */
   private void resetRelevantNonspecificFlag() {
-    this.isAddressRelevantButNonspecificOrNonresidential = false;
+    this.isAddressRelevantButNotSpecificOrResidential = false;
   }
 
   @Override
@@ -214,7 +214,7 @@ public class DataServlet extends HttpServlet {
   void parseResponseForRelevancy(String addressElectionResponse) {
     JsonObject responseJson = new JsonParser().parse(addressElectionResponse).getAsJsonObject();
     if (!responseJson.has("contests")) {
-      isAddressRelevantButNonspecificOrNonresidential = true;
+      isAddressRelevantButNotSpecificOrResidential = true;
     }
   }
 

--- a/project/src/main/webapp/candidate-page/candidate-page.component.js
+++ b/project/src/main/webapp/candidate-page/candidate-page.component.js
@@ -44,7 +44,10 @@ async function getCandidateInformation(scope) {
 
   // Add 2 components of information to the scope.
   scope.officialInfo = officialCandidateInfo;
-  scope.newsArticles = newsArticles;
+  // Sort news articles based on priority scores. News articles with smaller
+  // priority scores come first.
+  scope.newsArticles =
+      newsArticles.sort((x, y) => (x.priority >= y.priority) ? 1 : -1);
   scope.$apply();
 
   // Then add twitter information and load the widget

--- a/project/src/main/webapp/candidate-page/candidate-page.template.html
+++ b/project/src/main/webapp/candidate-page/candidate-page.template.html
@@ -22,8 +22,13 @@
     <h5>{{newsArticle.publisher}}</h5>
     <time>{{newsArticle.publishedDate}}</time>
     <div class="news-article-content">
+      <em>Content</em>
       <p>{{newsArticle.content}}</p>
-      <a href={{newsArticle.url}}>Read the full article</a>
+      <em>Abbreviated Content</em>
+      <p>{{newsArticle.abbreviatedContent}}</p>
+      <em>5-Sentence Summarized Content</em>
+      <p>{{newsArticle.summarizedContent}}</p>
+      <a href={{newsArticle.url}}>Read the original article</a>
     </div>
     <hr>
   </article>

--- a/project/src/main/webapp/directory.html
+++ b/project/src/main/webapp/directory.html
@@ -23,6 +23,7 @@
     <nav-bar></nav-bar>
     <main role="main">
       <directory-page id="elections-container"></directory-page>
+      <h3 id="alert"></h3>
     </main>
   </body>
 </html>

--- a/project/src/main/webapp/package-lock.json
+++ b/project/src/main/webapp/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "angular": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.0.tgz",
+      "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg=="
+    }
+  }
+}

--- a/project/src/main/webapp/script.js
+++ b/project/src/main/webapp/script.js
@@ -55,6 +55,7 @@ async function addBriefElectionCandidateInformation() {
   const response = await fetch(`/data?address=${address}&listAllElections=${listAllElections}`);
   const dataPackage = await response.json();
   const elections = dataPackage.electionsData;
+  const alert = dataPackage.alert;
 
   // Add (brief version) official election/candidate information to HTML.
   const electionsContainer = document.getElementById('elections-container');
@@ -64,6 +65,10 @@ async function addBriefElectionCandidateInformation() {
     const electionElement = constructElection(elections[electionIndex],
         electionIndex);
     electionsContainer.appendChild(electionElement);
+  }
+  // Set alert to the user if necessary.
+  if (alert) {
+    document.getElementById('alert').innerText = alert;
   }
 }
 

--- a/project/src/test/java/com/google/sps/DataServletTest.java
+++ b/project/src/test/java/com/google/sps/DataServletTest.java
@@ -1,0 +1,92 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import static com.google.common.truth.Truth.*;
+import static com.google.common.truth.Truth8.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.net.SocketException;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * A tester for the data servlet.
+ */
+@RunWith(JUnit4.class)
+public class DataServletTest {
+  // JSON response can be referenced below: @see <a href=
+  // "https://developers.google.com/civic-information/docs/using_api#voterinfoquery-response:">
+  // response structure</a>.
+  private static final String RELEVANT_ADDRESS_ELECTION_RESPONSE =
+      "{" +
+      "  contests: []" +
+      "}";
+  private static final String IRRELEVANT_ADDRESS_ELECTION_RESPONSE =
+      "{" +
+      "  states: []" +
+      "}";
+  private static final DataServlet dataServlet = new DataServlet();
+
+  @Test
+  public void requestHttpAndBuildJsonResponseFromCivicInformation_returnResponseStringAsIs()
+      throws IOException, SocketException {
+    // Query the Civic Information API with a mock HTTP client + mock callback function of type
+    // {@code ResponseHandler<String>} that converts any {@code HttpResponse} response to {@code
+    // RELEVANT_ADDRESS_ELECTION_RESPONSE}. {@code httpGet} is irrelevant in this test. The
+    // method should return the response as is without changing it.
+    CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+    HttpGet httpGet = new HttpGet("");
+    ArgumentCaptor<ResponseHandler<String>> argumentCaptor =
+        ArgumentCaptor.forClass(ResponseHandler.class);
+    when(httpClient.execute(anyObject(), argumentCaptor.capture()))
+        .thenReturn(RELEVANT_ADDRESS_ELECTION_RESPONSE);
+    String responseBody =
+        dataServlet.requestHttpAndBuildJsonResponseFromCivicInformation(httpClient, httpGet);
+    assertThat(responseBody).isEqualTo(RELEVANT_ADDRESS_ELECTION_RESPONSE);
+  }
+
+  @Test
+  public void parseResponseForRelevancy_relevantElection() {
+    // Parse JSON-formatted String {@code RELEVANT_ADDRESS_ELECTION_RESPONSE} and see that it
+    // indicates the election is relevant to the address according to the Civic Information
+    // API response structure.
+    assertThat(dataServlet.parseResponseForRelevancy(RELEVANT_ADDRESS_ELECTION_RESPONSE))
+        .isTrue();
+  }
+
+  @Test
+  public void parseResponseForRelevancy_irrelevantElection() {
+    // Parse JSON-formatted String {@code IRRELEVANT_ADDRESS_ELECTION_RESPONSE} and see that it
+    // indicates the election is irrelevant to the address according to the Civic Information
+    // API response structure.
+    assertThat(dataServlet.parseResponseForRelevancy(IRRELEVANT_ADDRESS_ELECTION_RESPONSE))
+        .isFalse();
+  }
+}

--- a/project/src/test/java/com/google/sps/DataServletTest.java
+++ b/project/src/test/java/com/google/sps/DataServletTest.java
@@ -110,7 +110,7 @@ public class DataServletTest {
     // indicates the election is relevant to the address and the address is both specific and
     // counts as a residential address, according to the Civic Information API response structure.
     dataServlet.parseResponseForRelevancy(RELEVANT_ADDRESS_ELECTION_RESPONSE);
-    assertThat(dataServlet.isAddressRelevantButNonspecificOrNonresidential).isFalse();
+    assertThat(dataServlet.isAddressRelevantButNotSpecificOrResidential).isFalse();
   }
 
   @Test
@@ -118,9 +118,9 @@ public class DataServletTest {
     // Parse JSON-formatted String {@code RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE} and see
     // that it,indicates the election is probably relevant to the address according to the Civic
     // Information API response structure, but the address is nonspecific.
-    dataServlet.isAddressRelevantButNonspecificOrNonresidential = false;
+    dataServlet.isAddressRelevantButNotSpecificOrResidential = false;
     dataServlet.parseResponseForRelevancy(RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE);
-    assertThat(dataServlet.isAddressRelevantButNonspecificOrNonresidential).isTrue();
+    assertThat(dataServlet.isAddressRelevantButNotSpecificOrResidential).isTrue();
   }
 
   @Test

--- a/project/src/test/java/com/google/sps/DataServletTest.java
+++ b/project/src/test/java/com/google/sps/DataServletTest.java
@@ -84,7 +84,7 @@ public class DataServletTest {
   private static final DataServlet dataServlet = new DataServlet();
 
   @Test
-  public void requestHttpAndBuildJsonResponseFromCivicInformation_returnResponseStringAsIs()
+  public void requestHttpAndBuildCivicInfoResponse_returnResponseStringAsIs()
       throws IOException, SocketException {
     // Query the Civic Information API with a mock HTTP client + mock callback function of type
     // {@code ResponseHandler<String>} that converts any {@code HttpResponse} response to {@code
@@ -97,7 +97,8 @@ public class DataServletTest {
     when(httpClient.execute(anyObject(), argumentCaptor.capture()))
         .thenReturn(RELEVANT_ADDRESS_ELECTION_RESPONSE);
     String responseBody =
-        dataServlet.requestHttpAndBuildJsonResponseFromCivicInformation(httpClient, httpGet);
+        dataServlet.requestHttpAndBuildCivicInfoResponse(httpClient, httpGet);
+    httpClient.close();
     assertThat(responseBody).isEqualTo(RELEVANT_ADDRESS_ELECTION_RESPONSE);
   }
 

--- a/project/src/test/java/com/google/sps/DataServletTest.java
+++ b/project/src/test/java/com/google/sps/DataServletTest.java
@@ -105,10 +105,10 @@ public class DataServletTest {
   @Test
   public void parseResponseForRelevancy_relevantElection() {
     // Parse JSON-formatted String {@code RELEVANT_ADDRESS_ELECTION_RESPONSE} and see that it
-    // indicates the election is relevant to the address according to the Civic Information
-    // API response structure.
-    assertThat(dataServlet.parseResponseForRelevancy(RELEVANT_ADDRESS_ELECTION_RESPONSE))
-        .isTrue();
+    // indicates the election is relevant to the address and the address is both specific and
+    // counts as a residential address, according to the Civic Information API response structure.
+    dataServlet.parseResponseForRelevancy(RELEVANT_ADDRESS_ELECTION_RESPONSE);
+    assertThat(dataServlet.isAddressRelevantButNonspecificOrNonresidential).isFalse();
   }
 
   @Test
@@ -116,11 +116,9 @@ public class DataServletTest {
     // Parse JSON-formatted String {@code RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE} and see
     // that it,indicates the election is probably relevant to the address according to the Civic
     // Information API response structure, but the address is nonspecific.
-    dataServlet.isAddressRelevantButNonspecific = false;
-    assertThat(
-        dataServlet.parseResponseForRelevancy(RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE))
-        .isTrue();
-    assertThat(dataServlet.isAddressRelevantButNonspecific).isTrue();
+    dataServlet.isAddressRelevantButNonspecificOrNonresidential = false;
+    dataServlet.parseResponseForRelevancy(RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE);
+    assertThat(dataServlet.isAddressRelevantButNonspecificOrNonresidential).isTrue();
   }
 
   @Test
@@ -128,7 +126,8 @@ public class DataServletTest {
     // Parse JSON-formatted String {@code IRRELEVANT_ADDRESS_ELECTION_RESPONSE} and see that it
     // indicates the election is irrelevant to the address according to the Civic Information
     // API response structure.
-    assertThat(dataServlet.parseResponseForRelevancy(IRRELEVANT_ADDRESS_ELECTION_RESPONSE))
-        .isFalse();
+    dataServlet.isAddressRelevantButNonspecificOrNonresidential = false;
+    dataServlet.parseResponseForRelevancy(IRRELEVANT_ADDRESS_ELECTION_RESPONSE);
+    assertThat(dataServlet.isAddressRelevantButNonspecificOrNonresidential).isTrue();
   }
 }

--- a/project/src/test/java/com/google/sps/DataServletTest.java
+++ b/project/src/test/java/com/google/sps/DataServletTest.java
@@ -46,11 +46,27 @@ public class DataServletTest {
   // response structure</a>.
   private static final String RELEVANT_ADDRESS_ELECTION_RESPONSE =
       "{" +
-      "  contests: []" +
+      "  state: [" +
+      "    {" +
+      "      sources: [" +
+      "        {" +
+      "          name: \"Voting Information Project\"" +
+      "        }" +
+      "      ]" +
+      "    }" +
+      "  ]" +
       "}";
   private static final String IRRELEVANT_ADDRESS_ELECTION_RESPONSE =
       "{" +
-      "  states: []" +
+      "  state: [" +
+      "    {" +
+      "      sources: [" +
+      "        {" +
+      "          name: \"\"" +
+      "        }" +
+      "      ]" +
+      "    }" +
+      "  ]" +
       "}";
   private static final DataServlet dataServlet = new DataServlet();
 

--- a/project/src/test/java/com/google/sps/DataServletTest.java
+++ b/project/src/test/java/com/google/sps/DataServletTest.java
@@ -46,6 +46,19 @@ public class DataServletTest {
   // response structure</a>.
   private static final String RELEVANT_ADDRESS_ELECTION_RESPONSE =
       "{" +
+      "  contests: []," +
+      "  state: [" +
+      "    {" +
+      "      sources: [" +
+      "        {" +
+      "          name: \"Voting Information Project\"" +
+      "        }" +
+      "      ]" +
+      "    }" +
+      "  ]" +
+      "}";
+  private static final String RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE =
+      "{" +
       "  state: [" +
       "    {" +
       "      sources: [" +
@@ -95,6 +108,18 @@ public class DataServletTest {
     // API response structure.
     assertThat(dataServlet.parseResponseForRelevancy(RELEVANT_ADDRESS_ELECTION_RESPONSE))
         .isTrue();
+  }
+
+  @Test
+  public void parseResponseForRelevancy_relevantNonspecificElection() {
+    // Parse JSON-formatted String {@code RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE} and see
+    // that it,indicates the election is probably relevant to the address according to the Civic
+    // Information API response structure, but the address is nonspecific.
+    dataServlet.isAddressRelevantButNonspecific = false;
+    assertThat(
+        dataServlet.parseResponseForRelevancy(RELEVANT_NONSPECIFIC_ADDRESS_ELECTION_RESPONSE))
+        .isTrue();
+    assertThat(dataServlet.isAddressRelevantButNonspecific).isTrue();
   }
 
   @Test


### PR DESCRIPTION
### Implement location-based search: user input address resolution when serving information, and write unit tests.

### What is a quick description of the change?

**1. Implement location-based search [info serving]: user input address resolution. Checking which elections are relevant to the address by querying the Civic Information API.**
- The Civic Information API returns different response content when the election is relevant or irrelevant to the address, while the HTTP responses will all be successful.

**2. Decouple address resolution logic in DataServlet: split up the API query and the String response parsing.**

**3. Write unit tests.**

**4. Update README about adding an API key.**

### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [ x ] Test written/updating
- [ x ] Tests passing
- [ x ] Coding style (indentation, etc)

Please explain why any are not present, if any.