### PR TITLE
Implement data expiration and deletion mechanism, add lastModified field to Datastore entities, and write unit tests.

### DIFF
--- a/info-compiler/README.md
+++ b/info-compiler/README.md
@@ -29,6 +29,8 @@ To use the code, please prepare and put the following configurations in com.goog
 - Name of Cloud Storage bucket that holds the OpenNLP model files (referenced in com.google.sps.webcrawler.NewsContentProcessor)
 - Name of the OpenNLP "Sentence Detector" model file (referenced in com.google.sps.webcrawler.NewsContentProcessor)
 - Name of the OpenNLP "Tokenizer" model file (referenced in com.google.sps.webcrawler.NewsContentProcessor)
+- Maximum duration for compiled data to be considered outdated. This should be smaller than the time it takes for InfoCompiler
+    to run again/enter the next cycle (referenced in com.google.sps.infocompiler.InfoCompiler)
 
 Additionally, for respecting the query rate limit (250 queries/100 seconds) of the Civic Information API, InfoCompiler
 needs to pause between queries. Set how much to shorten/extend the pause between queries, relative to the minimum pause

--- a/info-compiler/pom.xml
+++ b/info-compiler/pom.xml
@@ -71,6 +71,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
       <version>3.6.1</version>
     </dependency>

--- a/info-compiler/src/main/java/com/google/sps/infocompiler/Config.java
+++ b/info-compiler/src/main/java/com/google/sps/infocompiler/Config.java
@@ -27,6 +27,9 @@ public class Config {
   public static final String OPEN_NLP_MODEL_FILES_BUCKET_NAME = "";
   public static final String OPEN_NLP_SENTENCE_DETECTOR_FILE = "en-sent.bin";
   public static final String OPEN_NLP_TOKENIZER_FILE = "en-token.bin";
+  // This should be shorter than or equal to the time it takes for the next cycle of InfoCompiler
+  // to run.
+  public static final long DATA_EXPIRATION_SECONDS = 60 * 60 * 12;
 
   // For respecting the query rate limit (250 queries/100 seconds) of the Civic Information API:
   // With Cloud Functions deployment: How much to shorten/extend the pause between queries, relative

--- a/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
+++ b/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
@@ -384,6 +384,10 @@ public class InfoCompiler {
     // @TODO [May expand to other information to uniquely identify a candidate. Currently,
     // candidate information includes only name and party affiliation.]
     long candidateId = (long) (name.hashCode() + party.hashCode());
+    StringValue candidateIdString = StringValue.newBuilder(Long.toString(candidateId)).build();
+    if (candidateIds.contains(candidateIdString)) {
+      return;
+    }
     Key candidateKey =
         datastore.newKeyFactory()
             .setKind("Candidate")
@@ -395,7 +399,7 @@ public class InfoCompiler {
             .set("lastModified", Timestamp.now())
             .build();
     datastore.put(candidateEntity);
-    candidateIds.add(StringValue.newBuilder(Long.toString(candidateId)).build());
+    candidateIds.add(candidateIdString);
     candidateIncumbency.add(BooleanValue.newBuilder(false).build());
 
     compileAndStoreCandidateNewsArticlesInDatabase(name, new Long(candidateId).toString(), party);

--- a/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
+++ b/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
@@ -81,6 +81,8 @@ public class InfoCompiler {
           Config.PROJECT_ID);
   private static final String DATASTORE_BULK_DELETE_JOB_NAME =
       Config.PROJECT_ID + "_datastore_bulk_delete";
+  // This intermediary variable is set up for testing purposes.
+  static long DATA_EXPIRATION_SECONDS = Config.DATA_EXPIRATION_SECONDS;
   Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
   WebCrawler webCrawler;
   List<String> electionQueryIds;
@@ -395,7 +397,7 @@ public class InfoCompiler {
   private void clearOutdatedInfo() {
     Timestamp expirationTime =
         Timestamp.ofTimeSecondsAndNanos(
-            Timestamp.now().getSeconds() - Config.DATA_EXPIRATION_SECONDS, 0);
+            Timestamp.now().getSeconds() - DATA_EXPIRATION_SECONDS, 0);
     clearOutdatedEntities("Election", expirationTime);
     clearOutdatedEntities("Candidate", expirationTime);
     clearOutdatedEntities("NewsArticle", expirationTime);

--- a/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
+++ b/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
@@ -356,10 +356,15 @@ public class InfoCompiler {
    * Capitalizes the first letter of each word in {@code phrase} and make the rest of the letters
    * lowercase.
    */
-  private String capitalizeFirstLetterOfEachWord(String phrase) {
+  String capitalizeFirstLetterOfEachWord(String phrase) {
     String[] words = phrase.split(" ");
     for (int i = 0; i < words.length; i++) {
-      words[i] = StringUtils.capitalize(words[i].toLowerCase());
+      String word = words[i];
+      if (word.substring(0, 1).equals("\"")) {
+        words[i] = "\"" + StringUtils.capitalize(word.substring(1).toLowerCase());
+      } else {
+        words[i] = StringUtils.capitalize(word.toLowerCase());
+      }
     }
     return StringUtils.join(words, " ");
   }

--- a/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
+++ b/info-compiler/src/main/java/com/google/sps/infocompiler/InfoCompiler.java
@@ -337,7 +337,8 @@ public class InfoCompiler {
       storeElectionContestCandidateInDatabase(
           (JsonObject) candidate,
           candidateIds,
-          candidateIncumbency);
+          candidateIncumbency,
+          electionEntity.getKey().getName());
       candidatePositions.add(
           StringValue.newBuilder(
               capitalizeFirstLetterOfEachWord(contest.get("office").getAsString())).build());
@@ -377,13 +378,14 @@ public class InfoCompiler {
    * deletion purposes.
    */
   void storeElectionContestCandidateInDatabase(JsonObject candidate,
-      List<Value<String>> candidateIds, List<Value<Boolean>> candidateIncumbency) {
+      List<Value<String>> candidateIds, List<Value<Boolean>> candidateIncumbency,
+      String electionName) {
     String name = candidate.get("name").getAsString();
     String rawParty = candidate.get("party").getAsString();
     String party = capitalizeFirstLetterOfEachWord(rawParty);
     // @TODO [May expand to other information to uniquely identify a candidate. Currently,
     // candidate information includes only name and party affiliation.]
-    long candidateId = (long) (name.hashCode() + party.hashCode());
+    long candidateId = (long) (name.hashCode() + party.hashCode() + electionName.hashCode());
     StringValue candidateIdString = StringValue.newBuilder(Long.toString(candidateId)).build();
     if (candidateIds.contains(candidateIdString)) {
       return;

--- a/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
+++ b/info-compiler/src/main/java/com/google/sps/webcrawler/WebCrawler.java
@@ -343,7 +343,8 @@ public class WebCrawler {
    * content} and {@code abbreviatedContent} are excluded form database indexes, which are
    * additional data structures built to enable efficient lookup on non-keyed properties. Because
    * we will not query {@code NewsArticle} Datastore entities via {@code content} or
-   * {@code abbreviatedContent}, we will not use indexes regardless.
+   * {@code abbreviatedContent}, we will not use indexes regardless. Set the last modified time
+   * for deletion purposes.
    */
   public void storeInDatabase(String candidateId, NewsArticle newsArticle) {
     Key newsArticleKey =
@@ -367,6 +368,7 @@ public class WebCrawler {
                                       Timestamp.of(
                                           newsArticle.getPublishedDate())).build())
             .set("priority", newsArticle.getPriority())
+            .set("lastModified", Timestamp.now())
             .build();
     datastore.put(newsArticleEntity);
   }

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -64,6 +64,8 @@ import org.mockito.ArgumentCaptor;
 @RunWith(JUnit4.class)
 public final class InfoCompilerTest {
   private static final int ADDRESS_NUMBER = 957; // After screening.
+  private static String CORRECT_FORMAT_NAME = "Andrew Cuomo";
+  private static String CORRECT_FORMAT_NAME_IN_QUOTES = "\"Andrew Cuomo\"";
   private static final String ADDRESS = ",NY,New York,,,,,10028,,,,,East,,,84,Street,,,,144";
   private static final String STATE = "NY";
   private static final String NONTEST_ELECTION_QUERY_ID =
@@ -248,6 +250,31 @@ public final class InfoCompilerTest {
     assertThat(electionEntity.getString("state")).isEqualTo("");
     assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).compareTo(past) >= 0)
         .isTrue();
+  }
+
+  @Test
+  public void capitalizeFirstLetterOfEachWord_checkDifferentNames()
+      throws IOException {
+    // Capitalize the first letter of each word and make the rest of the letters lowercase.
+    assertThat(infoCompiler.capitalizeFirstLetterOfEachWord("Andrew Cuomo"))
+        .isEqualTo(CORRECT_FORMAT_NAME);
+    assertThat(infoCompiler.capitalizeFirstLetterOfEachWord("andrew cuomo"))
+        .isEqualTo(CORRECT_FORMAT_NAME);
+    assertThat(infoCompiler.capitalizeFirstLetterOfEachWord("ANDREW CUOMO"))
+        .isEqualTo(CORRECT_FORMAT_NAME);
+  }
+
+  @Test
+  public void capitalizeFirstLetterOfEachWord_checkDifferentNamesInQuotes()
+      throws IOException {
+    // Within the quotation marks, capitalize the first letter of each word and make the rest of
+    // the letters lowercase.
+    assertThat(infoCompiler.capitalizeFirstLetterOfEachWord("\"Andrew Cuomo\""))
+        .isEqualTo(CORRECT_FORMAT_NAME_IN_QUOTES);
+    assertThat(infoCompiler.capitalizeFirstLetterOfEachWord("\"andrew cuomo\""))
+        .isEqualTo(CORRECT_FORMAT_NAME_IN_QUOTES);
+    assertThat(infoCompiler.capitalizeFirstLetterOfEachWord("\"ANDREW CUOMO\""))
+        .isEqualTo(CORRECT_FORMAT_NAME_IN_QUOTES);
   }
 
   @Test

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -205,8 +205,7 @@ public final class InfoCompilerTest {
     assertThat(electionEntity.getList("candidateIds")).isEmpty();
     assertThat(electionEntity.getList("candidateIncumbency")).isEmpty();
     assertThat(electionEntity.getString("state")).isEqualTo(STATE);
-    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).getSeconds()
-                    >= past.getSeconds())
+    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).compareTo(past) >= 0)
         .isTrue();
   }
 
@@ -247,8 +246,7 @@ public final class InfoCompilerTest {
     assertThat(electionEntity.getList("candidateIds")).isEmpty();
     assertThat(electionEntity.getList("candidateIncumbency")).isEmpty();
     assertThat(electionEntity.getString("state")).isEqualTo("");
-    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).getSeconds()
-                    >= past.getSeconds())
+    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).compareTo(past) >= 0)
         .isTrue();
   }
 
@@ -309,8 +307,7 @@ public final class InfoCompilerTest {
     assertThat(candidateEntity.getString("name")).isEqualTo(candidate.get("name").getAsString());
     assertThat(candidateEntity.getString("partyAffiliation"))
         .isEqualTo(candidate.get("party").getAsString() + " Party");
-    assertThat(((Timestamp) candidateEntity.getValue("lastModified").get()).getSeconds()
-                    >= past.getSeconds())
+    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).compareTo(past) >= 0)
         .isTrue();
   }
 
@@ -363,8 +360,7 @@ public final class InfoCompilerTest {
     assertThat(electionEntity.getString("queryId")).isEqualTo(election.get("id").getAsString());
     assertThat(electionEntity.getTimestamp("date").toDate()).isEqualTo(date);
     assertThat(electionEntity.getString("state")).isEqualTo(STATE);
-    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).getSeconds()
-                    >= past.getSeconds())
+    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).compareTo(past) >= 0)
         .isTrue();
     List<Value<String>> candidatePositions =
         new ArrayList<>(electionEntity.getList("candidatePositions"));
@@ -395,8 +391,7 @@ public final class InfoCompilerTest {
     assertThat(candidateEntity.getString("name")).isEqualTo(candidate.get("name").getAsString());
     assertThat(candidateEntity.getString("partyAffiliation"))
         .isEqualTo(candidate.get("party").getAsString() + " Party");
-    assertThat(((Timestamp) candidateEntity.getValue("lastModified").get()).getSeconds()
-                    >= past.getSeconds())
+    assertThat(((Timestamp) electionEntity.getValue("lastModified").get()).compareTo(past) >= 0)
         .isTrue();
   }
 
@@ -456,7 +451,6 @@ public final class InfoCompilerTest {
       throws IOException {
     // Execute the entire information compilation process and set {@code DATA_EXPIRATION_SECONDS}
     // such that all newly added would be considered outdated immediately and thus cleared.
-    Timestamp past = Timestamp.now();
     JsonObject electionJsonCopy = electionJson.deepCopy();
     JsonObject election =
         ((JsonObject) electionJsonCopy.getAsJsonArray("elections").get(0));

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -294,7 +294,8 @@ public final class InfoCompilerTest {
     election.addProperty("ocdDivisionId", "ocd-division/country:us/state:" + STATE.toLowerCase());
     JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
-                                + candidate.get("party").getAsString().hashCode());
+                                + candidate.get("party").getAsString().hashCode()
+                                + election.get("name").getAsString().hashCode());
     infoCompiler.electionQueryIds = new ArrayList<>();
     infoCompiler.storeBaseElectionInDatabase(election);
     infoCompiler.storeElectionContestInDatabase(election.get("id").getAsString(),
@@ -363,7 +364,8 @@ public final class InfoCompilerTest {
     doReturn(contestsResponse).when(infoCompilerSpy).queryCivicInformation(eq(CONTEST_QUERY_URL));
     JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
-                                + candidate.get("party").getAsString().hashCode());
+                                + candidate.get("party").getAsString().hashCode()
+                                + election.get("name").getAsString().hashCode());
     String[] yearMonthDay = election.get("electionDay").getAsString().split("-");
     Date date = new Date(
         Integer.parseInt(yearMonthDay[0]) - 1900,
@@ -446,7 +448,8 @@ public final class InfoCompilerTest {
     doReturn(contestsResponse).when(infoCompilerSpy).queryCivicInformation(eq(CONTEST_QUERY_URL));
     JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
-                                + candidate.get("party").getAsString().hashCode());
+                                + candidate.get("party").getAsString().hashCode()
+                                + election.get("name").getAsString().hashCode());
     String[] yearMonthDay = election.get("electionDay").getAsString().split("-");
     Date date = new Date(
         Integer.parseInt(yearMonthDay[0]) - 1900,
@@ -496,7 +499,8 @@ public final class InfoCompilerTest {
     doReturn(contestsResponse).when(infoCompilerSpy).queryCivicInformation(eq(CONTEST_QUERY_URL));
     JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
-                                + candidate.get("party").getAsString().hashCode());
+                                + candidate.get("party").getAsString().hashCode()
+                                + election.get("name").getAsString().hashCode());
     String[] yearMonthDay = election.get("electionDay").getAsString().split("-");
     Date date = new Date(
         Integer.parseInt(yearMonthDay[0]) - 1900,

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -141,13 +141,13 @@ public final class InfoCompilerTest {
     infoCompiler = new InfoCompiler(datastore);
   }
 
-  @Test
-  public void parseAddressesFromDataset_regularParse() {
-    // The list of U.S. addresses in the dataset should contains {@code ADDRESS_NUMBER} addresses
-    // and contain {@code ADDRESS}.
-    assertThat(infoCompiler.addresses).hasSize(ADDRESS_NUMBER);
-    assertThat(infoCompiler.addresses).contains(ADDRESS);
-  }
+  // @Test
+  // public void parseAddressesFromDataset_regularParse() {
+  //   // The list of U.S. addresses in the dataset should contains {@code ADDRESS_NUMBER} addresses
+  //   // and contain {@code ADDRESS}.
+  //   assertThat(infoCompiler.addresses).hasSize(ADDRESS_NUMBER);
+  //   assertThat(infoCompiler.addresses).contains(ADDRESS);
+  // }
 
   @Test
   public void queryCivicInformation_succeedWithMockResponse() throws Exception {
@@ -325,30 +325,18 @@ public final class InfoCompilerTest {
     JsonObject election =
         ((JsonObject) electionJsonCopy.getAsJsonArray("elections").get(0));
     election.addProperty("ocdDivisionId", "ocd-division/country:us/state:" + STATE.toLowerCase());
-    InfoCompiler infoCompilerMock = mock(InfoCompiler.class);
+    InfoCompiler infoCompiler = new InfoCompiler(this.datastore);
+    InfoCompiler infoCompilerSpy = spy(infoCompiler);
     // Set expiration time to a safely large value that will not cause new data to be cleared.
-    infoCompilerMock.DATA_EXPIRATION_SECONDS = 60 * 60 * 12;
-    infoCompilerMock.datastore = this.datastore;
-    infoCompilerMock.addresses = Arrays.asList(ADDRESS);
-    infoCompilerMock.webCrawler = mock(WebCrawler.class);
-    doCallRealMethod().when(infoCompilerMock).compileInfo();
-    doCallRealMethod().when(infoCompilerMock).queryAndStoreBaseElectionInfo();
-    doCallRealMethod().when(infoCompilerMock).queryAndStoreElectionContestInfo();
-    doCallRealMethod()
-        .when(infoCompilerMock).queryAndStoreElectionContestInfo(anyString(), anyString());
-    doCallRealMethod().when(infoCompilerMock).queryAndStore(anyString(), anyString(), anyObject());
-    doCallRealMethod().when(infoCompilerMock).storeBaseElectionInDatabase(anyObject());
-    doCallRealMethod()
-        .when(infoCompilerMock).storeElectionContestInDatabase(anyString(), anyObject());
-    doCallRealMethod()
-        .when(infoCompilerMock)
-            .storeElectionContestCandidateInDatabase(anyObject(), anyObject(), anyObject());
-    when(infoCompilerMock.queryCivicInformation(eq(ELECTION_QUERY_URL))).thenReturn(electionJsonCopy);
+    infoCompilerSpy.DATA_EXPIRATION_SECONDS = 60 * 60 * 12;
+    infoCompilerSpy.addresses = Arrays.asList(ADDRESS);
+    infoCompilerSpy.webCrawler = mock(WebCrawler.class);
+    doReturn(electionJsonCopy).when(infoCompilerSpy).queryCivicInformation(eq(ELECTION_QUERY_URL));
     JsonArray contests = new JsonArray();
     contests.add(singleContestJson);
     JsonObject contestsResponse = new JsonObject();
     contestsResponse.add("contests", contests);
-    when(infoCompilerMock.queryCivicInformation(eq(CONTEST_QUERY_URL))).thenReturn(contestsResponse);
+    doReturn(contestsResponse).when(infoCompilerSpy).queryCivicInformation(eq(CONTEST_QUERY_URL));
     JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
                                 + candidate.get("party").getAsString().hashCode());
@@ -360,7 +348,7 @@ public final class InfoCompilerTest {
         4,
         0);
 
-    infoCompilerMock.compileInfo();
+    infoCompilerSpy.compileInfo();
 
     // Check election data.
     Query<Entity> electionQuery =
@@ -424,28 +412,16 @@ public final class InfoCompilerTest {
         ((JsonObject) electionJsonCopy.getAsJsonArray("elections").get(0));
     election.addProperty("ocdDivisionId", "ocd-division/country:us/state:" + STATE.toLowerCase());
     election.addProperty("id", InfoCompiler.TEST_VIP_ELECTION_QUERY_ID);
-    InfoCompiler infoCompilerMock = mock(InfoCompiler.class);
-    infoCompilerMock.datastore = this.datastore;
-    infoCompilerMock.addresses = Arrays.asList(ADDRESS);
-    infoCompilerMock.webCrawler = mock(WebCrawler.class);
-    doCallRealMethod().when(infoCompilerMock).compileInfo();
-    doCallRealMethod().when(infoCompilerMock).queryAndStoreBaseElectionInfo();
-    doCallRealMethod().when(infoCompilerMock).queryAndStoreElectionContestInfo();
-    doCallRealMethod()
-        .when(infoCompilerMock).queryAndStoreElectionContestInfo(anyString(), anyString());
-    doCallRealMethod().when(infoCompilerMock).queryAndStore(anyString(), anyString(), anyObject());
-    doCallRealMethod().when(infoCompilerMock).storeBaseElectionInDatabase(anyObject());
-    doCallRealMethod()
-        .when(infoCompilerMock).storeElectionContestInDatabase(anyString(), anyObject());
-    doCallRealMethod()
-        .when(infoCompilerMock)
-            .storeElectionContestCandidateInDatabase(anyObject(), anyObject(), anyObject());
-    when(infoCompilerMock.queryCivicInformation(eq(ELECTION_QUERY_URL))).thenReturn(electionJsonCopy);
+    InfoCompiler infoCompiler = new InfoCompiler(this.datastore);
+    InfoCompiler infoCompilerSpy = spy(infoCompiler);
+    infoCompilerSpy.addresses = Arrays.asList(ADDRESS);
+    infoCompilerSpy.webCrawler = mock(WebCrawler.class);
+    doReturn(electionJsonCopy).when(infoCompilerSpy).queryCivicInformation(eq(ELECTION_QUERY_URL));
     JsonArray contests = new JsonArray();
     contests.add(singleContestJson);
     JsonObject contestsResponse = new JsonObject();
     contestsResponse.add("contests", contests);
-    when(infoCompilerMock.queryCivicInformation(eq(CONTEST_QUERY_URL))).thenReturn(contestsResponse);
+    doReturn(contestsResponse).when(infoCompilerSpy).queryCivicInformation(eq(CONTEST_QUERY_URL));
     JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
                                 + candidate.get("party").getAsString().hashCode());
@@ -457,7 +433,7 @@ public final class InfoCompilerTest {
         4,
         0);
 
-    infoCompilerMock.compileInfo();
+    infoCompilerSpy.compileInfo();
 
     // Check election data.
     Query<Entity> electionQuery =
@@ -485,30 +461,18 @@ public final class InfoCompilerTest {
     JsonObject election =
         ((JsonObject) electionJsonCopy.getAsJsonArray("elections").get(0));
     election.addProperty("ocdDivisionId", "ocd-division/country:us/state:" + STATE.toLowerCase());
-    InfoCompiler infoCompilerMock = mock(InfoCompiler.class);
+    InfoCompiler infoCompiler = new InfoCompiler(this.datastore);
+    InfoCompiler infoCompilerSpy = spy(infoCompiler);
     // Any new data will be seen as outdated and thus cleared.
-    infoCompilerMock.DATA_EXPIRATION_SECONDS = -1;
-    infoCompilerMock.datastore = this.datastore;
-    infoCompilerMock.addresses = Arrays.asList(ADDRESS);
-    infoCompilerMock.webCrawler = mock(WebCrawler.class);
-    doCallRealMethod().when(infoCompilerMock).compileInfo();
-    doCallRealMethod().when(infoCompilerMock).queryAndStoreBaseElectionInfo();
-    doCallRealMethod().when(infoCompilerMock).queryAndStoreElectionContestInfo();
-    doCallRealMethod()
-        .when(infoCompilerMock).queryAndStoreElectionContestInfo(anyString(), anyString());
-    doCallRealMethod().when(infoCompilerMock).queryAndStore(anyString(), anyString(), anyObject());
-    doCallRealMethod().when(infoCompilerMock).storeBaseElectionInDatabase(anyObject());
-    doCallRealMethod()
-        .when(infoCompilerMock).storeElectionContestInDatabase(anyString(), anyObject());
-    doCallRealMethod()
-        .when(infoCompilerMock)
-            .storeElectionContestCandidateInDatabase(anyObject(), anyObject(), anyObject());
-    when(infoCompilerMock.queryCivicInformation(eq(ELECTION_QUERY_URL))).thenReturn(electionJsonCopy);
+    infoCompilerSpy.DATA_EXPIRATION_SECONDS = -1;
+    infoCompilerSpy.addresses = Arrays.asList(ADDRESS);
+    infoCompilerSpy.webCrawler = mock(WebCrawler.class);
+    doReturn(electionJsonCopy).when(infoCompilerSpy).queryCivicInformation(eq(ELECTION_QUERY_URL));
     JsonArray contests = new JsonArray();
     contests.add(singleContestJson);
     JsonObject contestsResponse = new JsonObject();
     contestsResponse.add("contests", contests);
-    when(infoCompilerMock.queryCivicInformation(eq(CONTEST_QUERY_URL))).thenReturn(contestsResponse);
+    doReturn(contestsResponse).when(infoCompilerSpy).queryCivicInformation(eq(CONTEST_QUERY_URL));
     JsonObject candidate = (JsonObject) singleContestJson.getAsJsonArray("candidates").get(0);
     Long candidateId = new Long(candidate.get("name").getAsString().hashCode()
                                 + candidate.get("party").getAsString().hashCode());
@@ -520,7 +484,7 @@ public final class InfoCompilerTest {
         4,
         0);
 
-    infoCompilerMock.compileInfo();
+    infoCompilerSpy.compileInfo();
 
     // Check election data.
     Query<Entity> electionQuery =

--- a/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/InfoCompilerTest.java
@@ -141,13 +141,13 @@ public final class InfoCompilerTest {
     infoCompiler = new InfoCompiler(datastore);
   }
 
-  // @Test
-  // public void parseAddressesFromDataset_regularParse() {
-  //   // The list of U.S. addresses in the dataset should contains {@code ADDRESS_NUMBER} addresses
-  //   // and contain {@code ADDRESS}.
-  //   assertThat(infoCompiler.addresses).hasSize(ADDRESS_NUMBER);
-  //   assertThat(infoCompiler.addresses).contains(ADDRESS);
-  // }
+  @Test
+  public void parseAddressesFromDataset_regularParse() {
+    // The list of U.S. addresses in the dataset should contains {@code ADDRESS_NUMBER} addresses
+    // and contain {@code ADDRESS}.
+    assertThat(infoCompiler.addresses).hasSize(ADDRESS_NUMBER);
+    assertThat(infoCompiler.addresses).contains(ADDRESS);
+  }
 
   @Test
   public void queryCivicInformation_succeedWithMockResponse() throws Exception {

--- a/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
+++ b/info-compiler/src/test/java/com/google/sps/WebCrawlerTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
+import com.google.cloud.Timestamp;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.sps.data.NewsArticle;
@@ -376,6 +377,7 @@ public final class WebCrawlerTest {
     // and successfully stores said entity into the database. Use a Datastore emulator to simulate
     // operations, as opposed to a Mockito mock of Datastore which does not provide mocking of all
     // required operations.
+    Timestamp past = Timestamp.now();
     NewsArticle expectedNewsArticle = new NewsArticle(VALID_URL, null, null, PRIORITY);
     expectedNewsArticle.setTitle(TITLE);
     expectedNewsArticle.setContent(CONTENT);
@@ -403,9 +405,15 @@ public final class WebCrawlerTest {
     assertThat(newsArticleEntity.getString("title")).isEqualTo(expectedNewsArticle.getTitle());
     assertThat(newsArticleEntity.getString("url")).isEqualTo(expectedNewsArticle.getUrl());
     assertThat(newsArticleEntity.getString("content")).isEqualTo(expectedNewsArticle.getContent());
-    assertThat(newsArticleEntity.getString("abbreviatedContent")).isEqualTo(EMPTY_ABBREVIATED_CONTENT);
-    assertThat(newsArticleEntity.getString("abbreviatedContent")).isEqualTo(EMPTY_SUMMARIZED_CONTENT);
-    assertThat(newsArticleEntity.getValue("priority").get()).isEqualTo(expectedNewsArticle.getPriority());
+    assertThat(newsArticleEntity.getString("abbreviatedContent"))
+        .isEqualTo(EMPTY_ABBREVIATED_CONTENT);
+    assertThat(newsArticleEntity.getString("abbreviatedContent"))
+        .isEqualTo(EMPTY_SUMMARIZED_CONTENT);
+    assertThat(newsArticleEntity.getValue("priority").get())
+        .isEqualTo(expectedNewsArticle.getPriority());
+    assertThat(((Timestamp) newsArticleEntity.getValue("lastModified").get()).getSeconds()
+                    >= past.getSeconds())
+        .isTrue();
   }
 
   @AfterClass


### PR DESCRIPTION
## Implement data expiration and deletion mechanism, add lastModified field to Datastore entities, and write unit tests.

### What is a quick description of the change?

**1. Define data expiration as the time after a Datastore entity was created or last updated exceeding some threshold.**
- This threshold is set to be shorter than or equal to the cycle duration until `InfoCompiler` runs again.

**2. Query for and delete outdated Datastore entities, after the compilation process.**
- Election and candidate entities have data that come directly from the Civic Information API response. However, news article entities take noticeable time to compile. Thus, if we were to clear the entire database and then add new information, there would be a period of time when nothing can be hosted on the web application. _To make sure we can continuously serve information, we decided to first add new information, and then remove outdated information (and figure out a way to compute outdatedness)._
- For election and candidate entities, `InfoCompiler` overwrites existing elections and candidates if they exist, so duplication in adding & deleting is minimized.

**3. Set a new `lastModified` field for election and candidate entities in `InfoCompiler`, and for news article entities in `WebCrawler`.**

**4. Write instructions in README.**



### Is this fixing an issue?

none

### Are there more details that are relevant?

none

### Check lists (check `x` in `[ ]` of list items)

- [ x ] Test written/updating
- [ x ] Tests passing
- [ x ] Coding style (indentation, etc)

Please explain why any are not present, if any.